### PR TITLE
add chromedriver arm support for mac

### DIFF
--- a/get_chrome_driver/enums/platform.py
+++ b/get_chrome_driver/enums/platform.py
@@ -8,5 +8,5 @@ class Platform(Enum):
     linux64 = "linux64"
     mac32 = "mac32"
     mac64 = "mac64"
-    mac_x64 = "mac-x64"
     mac_arm64 = "mac-arm64"
+    mac_x64 = "mac-x64"

--- a/get_chrome_driver/enums/platform.py
+++ b/get_chrome_driver/enums/platform.py
@@ -9,3 +9,4 @@ class Platform(Enum):
     mac32 = "mac32"
     mac64 = "mac64"
     mac_x64 = "mac-x64"
+    mac_arm64 = "mac-arm64"

--- a/get_chrome_driver/get_driver.py
+++ b/get_chrome_driver/get_driver.py
@@ -320,13 +320,18 @@ class GetChromeDriver:
             )
         elif os_platform == OsPlatform.mac:
             driver_file_ext = ""
+            if pl.processor() == "arm":
+                filename = f"{self.__chromedriver_str}-mac-arm64"
+            else:
+                filename = f"{self.__chromedriver_str}-mac-x64"
             old_driver_file_path_64 = os.path.join(
                 output_path,
-                f"{self.__chromedriver_str}-mac-x64",
+                filename,
                 f"{self.__chromedriver_str}{driver_file_ext}",
             )
             old_driver_file_parent_dir_64 = os.path.join(
-                output_path, f"{self.__chromedriver_str}-mac-x64"
+                output_path, 
+                filename
             )
         else:
             raise GetChromeDriverError("Could not determine OS")

--- a/get_chrome_driver/get_driver.py
+++ b/get_chrome_driver/get_driver.py
@@ -113,7 +113,10 @@ class GetChromeDriver:
                 if self.__arch == 64:
                     for driver in drivers or []:
                         if is_mac:
-                            _platform_64 = Platform.mac_x64.value
+                            if pl.processor() == "arm":
+                                _platform_64 = Platform.mac_arm64.value
+                            else:
+                                _platform_64 = Platform.mac_x64.value
                         else:
                             _platform_64 = platform_64
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 name = "get-chrome-driver"
-version = "1.3.19"
+version = "1.3.20"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Currently only the intel chromedriver is being downloaded for mac regardless of what your actual CPU architecture is. This will instead add a conditional that downloads the version applicable for your platform to run natively.
